### PR TITLE
fix: resolve certificate path for multi-domain certbot requests

### DIFF
--- a/assets/main.py
+++ b/assets/main.py
@@ -70,10 +70,7 @@ def handler(events, contexts):
   
 
 def domain_path_helper(domain: str):
-  d = domain.split('.')
-  try:
-    d.remove('*')
-  except:
-    pass
-  r = '.'.join(d)
-  return r
+  first_domain = domain.split(',')[0].strip()
+  if first_domain.startswith('*.'):
+    first_domain = first_domain[2:]
+  return first_domain


### PR DESCRIPTION
domain_path_helper split the entire DOMAIN_NAME string on "." and only removed a standalone "*" segment. For comma-separated requests such as "*.example.com,example.com", this produced "example.com,example.com", which does not match the lineage directory certbot actually creates.

Certbot names the lineage directory after the first domain in the list with the "*." wildcard prefix stripped. Match that behavior by taking the first comma-separated domain and removing any leading "*.", so the S3 upload reads from and writes to the correct path.