### PR TITLE
fix: avoid passing literal "undefined" to CUSTOM_PREFIX_DIRECTORY env var

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -75,12 +75,14 @@ export interface CertbotOptions {
 export class CertbotDnsRoute53JobPython extends Construct {
   constructor(scope: Construct, id: string, props: CertbotDnsRoute53JobProps ) {
     super(scope, id);
-    const certOptions = {
+    const certOptions: Record<string, string> = {
       BUCKET_NAME: props.destinationBucket.bucketName,
       EMAIL: props.certbotOptions.email,
       DOMAIN_NAME: props.certbotOptions.domainName,
-      CUSTOM_PREFIX_DIRECTORY: props.certbotOptions.customPrefixDirectory!,
     };
+    if (props.certbotOptions.customPrefixDirectory) {
+      certOptions.CUSTOM_PREFIX_DIRECTORY = props.certbotOptions.customPrefixDirectory;
+    }
 
     const lambdaFun = new LambdaPythonFunction(this, 'certbotDnsRoute53JobPythonLambda', {
       timeout: cdk.Duration.minutes(5),

--- a/test/certbot-lambda.test.ts
+++ b/test/certbot-lambda.test.ts
@@ -74,3 +74,32 @@ test('test PythonLambdaFunction', () => {
   });
 
 });
+
+test('CUSTOM_PREFIX_DIRECTORY is omitted when customPrefixDirectory is not set', () => {
+  const mockApp = new cdk.App();
+  const stack = new cdk.Stack(mockApp, 'teststack', { env: devEnv });
+  const bucket = new s3.Bucket(stack, 'testingBucket');
+  const zone = r53.HostedZone.fromHostedZoneAttributes(stack, 'zone', {
+    zoneName: mock.zoneName, hostedZoneId: mock.zoneId,
+  });
+  new CertbotDnsRoute53JobPython(stack, 'Testtask', {
+    certbotOptions: {
+      domainName: 'example.com',
+      email: 'user@example.com',
+    },
+    zone,
+    destinationBucket: bucket,
+  });
+  assertions.Template.fromStack(stack).hasResourceProperties('AWS::Lambda::Function', {
+    Environment: {
+      Variables: {
+        BUCKET_NAME: {
+          Ref: 'testingBucket9FA8E574',
+        },
+        EMAIL: 'user@example.com',
+        DOMAIN_NAME: 'example.com',
+        CUSTOM_PREFIX_DIRECTORY: assertions.Match.absent(),
+      },
+    },
+  });
+});


### PR DESCRIPTION
Closes #3128

##### 問題

`src/main.ts` 透過 non-null assertion 將 `customPrefixDirectory` 傳給 Lambda 的環境變數:

```typescript
CUSTOM_PREFIX_DIRECTORY: props.certbotOptions.customPrefixDirectory!,
```

但 `customPrefixDirectory` 是 optional 欄位。當呼叫端未提供時值為 `undefined`,而 TypeScript 的 `!` 只會抑制編譯器檢查、不會改變 runtime 的值,因此環境變數會被設成字面字串 `"undefined"`。

`assets/main.py` 的判斷:

```python
CUSTOM_PREFIX_DIRECTORY = os.getenv("CUSTOM_PREFIX_DIRECTORY")
if CUSTOM_PREFIX_DIRECTORY == None:
    ...
```

由於 env var 是 `"undefined"` 而非真的缺席,`None` 檢查會失敗,落到 `else` 分支,產生錯誤的 S3 path prefix。

##### 修正

只有在 `customPrefixDirectory` 有值時才設定該環境變數:

```typescript
const certOptions: Record<string, string> = {
  BUCKET_NAME: props.destinationBucket.bucketName,
  EMAIL: props.certbotOptions.email,
  DOMAIN_NAME: props.certbotOptions.domainName,
};
if (props.certbotOptions.customPrefixDirectory) {
  certOptions.CUSTOM_PREFIX_DIRECTORY = props.certbotOptions.customPrefixDirectory;
}
```

env var 未設定時 `os.getenv` 回傳 `None`,Python 端的判斷即可正確運作,無需改動。

##### 測試

新增測試驗證未設定 `customPrefixDirectory` 時環境變數會被省略(`Match.absent()`),既有測試維持通過。

https://claude.ai/code/session_01N3U7hP2YsBZTNiF1q1LuK6